### PR TITLE
Add a user nobody and a group users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,8 @@ FROM gcr.io/distroless/base
 
 COPY out/configmap-reload /configmap-reload
 
+RUN groupadd users && useradd -Mg users nobody
+RUN chown nobody:users configmap-reload
+USER nobody
+
 ENTRYPOINT ["/configmap-reload"]


### PR DESCRIPTION
Kubernetes requires a user other than root in secured environments. 
Other than that it's always good to run processes as non-root, even for not kubernetes environments.